### PR TITLE
defines Spec.Components.Schemas and Spec.Components.SecuritySchemes

### DIFF
--- a/component.go
+++ b/component.go
@@ -1,0 +1,34 @@
+package spec3
+
+import "github.com/go-openapi/spec"
+
+// Components holds a set of reusable objects for different aspects of the OAS.
+// All objects defined within the components object will have no effect on the API
+// unless they are explicitly referenced from properties outside the components object.
+//
+// see: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject
+type Components struct {
+	// Schemas holds reusable Schema Objects
+	Schemas Schemas `json:"schemas,omitempty"`
+	// SecuritySchemes holds reusable Security Scheme Objects
+	// see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
+	SecuritySchemes SecuritySchemes `json:"securitySchemes,omitempty"`
+	// the following fields are missing:
+	//
+	// responses	Map[string, Response Object | Reference Object]
+	// parameters	Map[string, Parameter Object | Reference Object]
+	// examples	Map[string, Example Object | Reference Object]
+	// requestBodies	Map[string, Request Body Object | Reference Object]
+	// headers	Map[string, Header Object | Reference Object]
+	// links	Map[string, Link Object | Reference Object]
+	// callbacks	Map[string, Callback Object | Reference Object]
+	//
+	// all fields are defined at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject
+}
+
+// SecuritySchemes holds reusable Security Scheme Objects
+// see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
+type SecuritySchemes map[string]*SecurityScheme
+
+// Schemas holds reusable Schema Objects
+type Schemas map[string]*spec.Schema

--- a/component_test.go
+++ b/component_test.go
@@ -1,0 +1,150 @@
+package spec3_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-openapi/spec"
+	"github.com/google/go-cmp/cmp"
+	"github.com/p0lyn0mial/spec3"
+)
+
+func TestSchemasJSONSerialization(t *testing.T) {
+	cases := []struct {
+		name                 string
+		components           spec3.Components
+		serializedComponents string
+	}{
+		{
+			name: "scenario1: smoke test serialization of spec3.Components.Schemas",
+			components: spec3.Components{
+				Schemas: map[string]*spec.Schema{
+					"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": &spec.Schema{
+						SchemaProps: spec.SchemaProps{
+							Description: "MutatingWebhook describes an admission webhook and the resources and operations it applies to.",
+							Type:        []string{"object"},
+							Properties: map[string]spec.Schema{
+								"name": {
+									SchemaProps: spec.SchemaProps{
+										Description: "The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where \"imagepolicy\" is the name of the webhook, and kubernetes.io is the name of the organization. Required.",
+										Type:        []string{"string"},
+										Format:      "",
+									},
+								},
+								"clientConfig": {
+									SchemaProps: spec.SchemaProps{
+										Description: "ClientConfig defines how to communicate with the hook. Required",
+										Ref:         spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"),
+									},
+								},
+								"rules": {
+									SchemaProps: spec.SchemaProps{
+										Description: "Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.",
+										Type:        []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Ref: spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.RuleWithOperations"),
+												},
+											},
+										},
+									},
+								},
+								"failurePolicy": {
+									SchemaProps: spec.SchemaProps{
+										Description: "FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.",
+										Type:        []string{"string"},
+										Format:      "",
+									},
+								},
+								"matchPolicy": {
+									SchemaProps: spec.SchemaProps{
+										Description: "matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".\n\n- Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.\n\n- Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.\n\nDefaults to \"Exact\"",
+										Type:        []string{"string"},
+										Format:      "",
+									},
+								},
+								"namespaceSelector": {
+									SchemaProps: spec.SchemaProps{
+										Description: "NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything.",
+										Ref:         spec.MustCreateRef("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
+									},
+								},
+								"objectSelector": {
+									SchemaProps: spec.SchemaProps{
+										Description: "ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.",
+										Ref:         spec.MustCreateRef("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
+									},
+								},
+								"sideEffects": {
+									SchemaProps: spec.SchemaProps{
+										Description: "SideEffects states whether this webhookk has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.",
+										Type:        []string{"string"},
+										Format:      "",
+									},
+								},
+								"timeoutSeconds": {
+									SchemaProps: spec.SchemaProps{
+										Description: "TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.",
+										Type:        []string{"integer"},
+										Format:      "int32",
+									},
+								},
+								"admissionReviewVersions": {
+									SchemaProps: spec.SchemaProps{
+										Description: "AdmissionReviewVersions is an ordered list of preferred AdmissionReview versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to ['v1beta1'].",
+										Type:        []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type:   []string{"string"},
+													Format: "",
+												},
+											},
+										},
+									},
+								},
+								"reinvocationPolicy": {
+									SchemaProps: spec.SchemaProps{
+										Description: "reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are \"Never\" and \"IfNeeded\".\n\nNever: the webhook will not be called more than once in a single admission evaluation.\n\nIfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.\n\nDefaults to \"Never\".",
+										Type:        []string{"string"},
+										Format:      "",
+									},
+								},
+							},
+							Required: []string{"name", "clientConfig"},
+						},
+					},
+				},
+			},
+			serializedComponents: `{"schemas":{"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook":{"description":"MutatingWebhook describes an admission webhook and the resources and operations it applies to.","type":"object","required":["name","clientConfig"],"properties":{"admissionReviewVersions":{"description":"AdmissionReviewVersions is an ordered list of preferred AdmissionReview versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to ['v1beta1'].","type":"array","items":{"type":"string"}},"clientConfig":{"description":"ClientConfig defines how to communicate with the hook. Required","$ref":"k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"},"failurePolicy":{"description":"FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.","type":"string"},"matchPolicy":{"description":"matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".\n\n- Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.\n\n- Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.\n\nDefaults to \"Exact\"","type":"string"},"name":{"description":"The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where \"imagepolicy\" is the name of the webhook, and kubernetes.io is the name of the organization. Required.","type":"string"},"namespaceSelector":{"description":"NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything.","$ref":"k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},"objectSelector":{"description":"ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.","$ref":"k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},"reinvocationPolicy":{"description":"reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are \"Never\" and \"IfNeeded\".\n\nNever: the webhook will not be called more than once in a single admission evaluation.\n\nIfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.\n\nDefaults to \"Never\".","type":"string"},"rules":{"description":"Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.","type":"array","items":{"$ref":"k8s.io/api/admissionregistration/v1beta1.RuleWithOperations"}},"sideEffects":{"description":"SideEffects states whether this webhookk has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.","type":"string"},"timeoutSeconds":{"description":"TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.","type":"integer","format":"int32"}}}}}`,
+		},
+
+		// scenario 2
+		{
+			name: "scenario2: schema can be defined as a ref, see: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject",
+			components: spec3.Components{
+				Schemas: map[string]*spec.Schema{
+					"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": &spec.Schema{
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"),
+						},
+					},
+				},
+			},
+			serializedComponents: `{"schemas":{"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook":{"$ref":"k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"}}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rawComponents, err := json.Marshal(tc.components)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stringComponents := string(rawComponents)
+			if !cmp.Equal(stringComponents, tc.serializedComponents) {
+				t.Fatalf("diff %s", cmp.Diff(stringComponents, tc.serializedComponents))
+			}
+		})
+	}
+}

--- a/security_scheme.go
+++ b/security_scheme.go
@@ -1,0 +1,89 @@
+package spec3
+
+import (
+	"encoding/json"
+
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/swag"
+)
+
+// SecurityScheme defines reusable Security Scheme Object
+// as described in https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
+type SecurityScheme struct {
+	// Refable is a simple object to allow referencing other components in the specification, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#referenceObject
+	spec.Refable
+	// SecuritySchemeProps defines a security scheme that can be used by the operations
+	SecuritySchemeProps
+	// VendorExtensible allows for adding additional fields, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#specification-extensions
+	spec.VendorExtensible
+}
+
+// MarshalJSON is a custom marshal function that knows how to
+// encode SecurityScheme as JSON
+func (s *SecurityScheme) MarshalJSON() ([]byte, error) {
+	b1, err := json.Marshal(s.SecuritySchemeProps)
+	if err != nil {
+		return nil, err
+	}
+	b2, err := json.Marshal(s.VendorExtensible)
+	if err != nil {
+		return nil, err
+	}
+	b3, err := json.Marshal(s.Refable)
+	if err != nil {
+		return nil, err
+	}
+	return swag.ConcatJSON(b1, b2, b3), nil
+}
+
+// SecuritySchemeProps defines a security scheme that can be used by the operations
+type SecuritySchemeProps struct {
+	// Type of the security scheme
+	Type string `json:"type,omitempty"`
+	// Description holds a short description for security scheme
+	Description string `json:"description,omitempty"`
+	// Name holds the name of the header, query or cookie parameter to be used
+	Name string `json:"name,omitempty"`
+	// In holds the location of the API key
+	In string `json:"in,omitempty"`
+	// Scheme holds the name of the HTTP Authorization scheme to be used in the Authorization header
+	Scheme string `json:"scheme,omitempty"`
+	// BearerFormat holds a hint to the client to identify how the bearer token is formatted
+	BearerFormat string `json:"bearerFormat,omitempty"`
+	// Flows contains configuration information for the flow types supported.
+	Flows map[string]*OAuthFlow `json:"flows,omitempty"`
+	// OpenIdConnectUrl holds an url to discover OAuth2 configuration values from
+	OpenIdConnectUrl string `json:"openIdConnectUrl,omitempty"`
+}
+
+// OAuthFlow contains configuration information for the flow types supported.
+type OAuthFlow struct {
+	OAuthFlowProps
+	// VendorExtensible allows for adding additional fields https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oauth-flow-object
+	spec.VendorExtensible
+}
+
+// MarshalJSON is a custom marshal function that knows how to encode OAuthFlow as JSON
+func (o *OAuthFlow) MarshalJSON() ([]byte, error) {
+	b1, err := json.Marshal(o.OAuthFlowProps)
+	if err != nil {
+		return nil, err
+	}
+	b2, err := json.Marshal(o.VendorExtensible)
+	if err != nil {
+		return nil, err
+	}
+	return swag.ConcatJSON(b1, b2), nil
+}
+
+// OAuthFlowProps holds configuration details for a supported OAuth Flow
+type OAuthFlowProps struct {
+	// AuthorizationUrl hold the authorization URL to be used for this flow
+	AuthorizationUrl string `json:"authorizationUrl,omitempty"`
+	// TokenUrl holds the token URL to be used for this flow
+	TokenUrl string `json:"tokenUrl,omitempty"`
+	// RefreshUrl holds the URL to be used for obtaining refresh tokens
+	RefreshUrl string `json:"refreshUrl,omitempty"`
+	// Scopes holds the available scopes for the OAuth2 security scheme
+	Scopes map[string]string `json:"scopes,omitempty"`
+}

--- a/security_scheme_test.go
+++ b/security_scheme_test.go
@@ -1,0 +1,88 @@
+package spec3_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/spec"
+	"github.com/google/go-cmp/cmp"
+	"github.com/p0lyn0mial/spec3"
+)
+
+func TestSecuritySchemaJSONSerialization(t *testing.T) {
+	cases := []struct {
+		name                     string
+		securitySchema           *spec3.SecurityScheme
+		serializedSecuritySchema string
+	}{
+		// scenario 1
+		{
+			name: "scenario1: basic authentication",
+			securitySchema: &spec3.SecurityScheme{
+				SecuritySchemeProps: spec3.SecuritySchemeProps{
+					Type:   "http",
+					Scheme: "basic",
+				},
+			},
+			serializedSecuritySchema: `{"type":"http","scheme":"basic"}`,
+		},
+
+		// scenario 2
+		{
+			name: "scenario2: JWT Bearer",
+			securitySchema: &spec3.SecurityScheme{
+				SecuritySchemeProps: spec3.SecuritySchemeProps{
+					Type:         "http",
+					Scheme:       "basic",
+					BearerFormat: "JWT",
+				},
+			},
+			serializedSecuritySchema: `{"type":"http","scheme":"basic","bearerFormat":"JWT"}`,
+		},
+
+		// scenario 3
+		{
+			name: "scenario3: implicit OAuth2",
+			securitySchema: &spec3.SecurityScheme{
+				SecuritySchemeProps: spec3.SecuritySchemeProps{
+					Type: "oauth2",
+					Flows: map[string]*spec3.OAuthFlow{
+						"implicit": &spec3.OAuthFlow{
+							OAuthFlowProps: spec3.OAuthFlowProps{
+								AuthorizationUrl: "https://example.com/api/oauth/dialog",
+								Scopes: map[string]string{
+									"write:pets": "modify pets in your account",
+									"read:pets":  "read your pets",
+								},
+							},
+						},
+					},
+				},
+			},
+			serializedSecuritySchema: `{"type":"oauth2","flows":{"implicit":{"authorizationUrl":"https://example.com/api/oauth/dialog","scopes":{"read:pets":"read your pets","write:pets":"modify pets in your account"}}}}`,
+		},
+
+		// scenario 4
+		{
+			name: "scenario4: reference Object",
+			securitySchema: &spec3.SecurityScheme{
+				Refable: spec.Refable{Ref: spec.MustCreateRef("k8s.io/api/foo/v1beta1b.bar")},
+			},
+			serializedSecuritySchema: `{"$ref":"k8s.io/api/foo/v1beta1b.bar"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rawSecuritySchema, err := json.Marshal(tc.securitySchema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stringSecuritySchema := string(rawSecuritySchema)
+			if !cmp.Equal(stringSecuritySchema, tc.serializedSecuritySchema) {
+				fmt.Println(stringSecuritySchema)
+				t.Fatalf("diff %s", cmp.Diff(stringSecuritySchema, tc.serializedSecuritySchema))
+			}
+		})
+	}
+}

--- a/spec.go
+++ b/spec.go
@@ -1,0 +1,9 @@
+package spec3
+
+// OpenAPI is an object that describes an API and conforms to the OpenAPI Specification.
+//
+// Note: at the moment this struct doesn't fully conforms to the OpenAPI Specification in version 3.0,
+//       it is just a proof of concept
+type OpenAPI struct {
+	Components Components `json:"components,omitempty"`
+}


### PR DESCRIPTION
this pull only defines `Schemas` and `SecuritySchemes` objects, implementation is based on `spec.Schema` (https://github.com/go-openapi/spec/blob/master/schema.go#L160)

see the spec: 
1. https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject
2. https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject